### PR TITLE
Fix weighted regression failure when IRR estimates approach 0/1

### DIFF
--- a/R/predict_tau.R
+++ b/R/predict_tau.R
@@ -133,8 +133,12 @@ predict_tau <- function(
                                                       data = dplyr::pick(everything()), 
                                                       clusters = id))) %>% 
     
-    # remove if estimated tau is 0 or 1
-    dplyr::filter(!(estimate %in% c(0, 1))) %>% 
+    # Remove boundary cases where estimate of reliability is 0 or 1.
+    # Due to floating-point arithmetic in `estimatr` / its RcppEigen C++ routines,
+    # sometimes the returned estimate is 1-.Machine$double.eps, which is not exactly == 1.
+    # We must use `dplyr::near()` to robustly handle near-equality by adding a tiny tolerance.
+    dplyr::filter(!dplyr::near(estimate, 0, tol = .Machine$double.eps^0.5)) %>%
+    dplyr::filter(!dplyr::near(estimate, 1, tol = .Machine$double.eps^0.5)) %>%
     
     # remove if all attributes are the same within task combinations
     dplyr::filter(x != 0) 


### PR DESCRIPTION
Fix a critical bug in IRR estimation where perfect reliability at low attribute differences caused weighted regression to fail due to floating-point arithmetic.

Problem: When all profile pairs at a given x value (where x is the # of attribute differences between profile pairs, as in predict_tau.R) showed perfect reliability, estimatr's C++ routines via RcppEigen would return coefficient estimates as 1-.Machine$double.eps rather than exactly 1, and the undefined standard errors as .Machine$double.eps. The existing exact equality filter (estimate %in% c(0,1)) failed to catch these boundary cases. Consequently, the weighted linear regression used to extrapolate IRR at x=0 assigned catastrophically large weights (1/.Machine$double.eps^2) to these observations, completely distorting the final IRR estimates. See [https://github.com/yhoriuchi/projoint/discussions/42#discussion-8252128](https://github.com/yhoriuchi/projoint/discussions/42#discussion-8252128) .

As noted in help(".Machine"), .Machine$double.eps, or machine epsilon, is the "smallest positive floating-point number x such that 1 + x != 1" and is used in computer arithmetic and C++ float arithmetic routines.

Solution: Replace strict equality checks with dplyr::near() using tolerance of .Machine$double.eps^0.5. This properly identifies and excludes boundary reliability estimates that are computationally indistinguishable from 0 or 1, preventing infinite or near-infinite weights in the regression model.

This ensures robust IRR estimation even when some attribute difference levels exhibit perfect or zero reliability in finite samples.